### PR TITLE
Expand  accepted method names

### DIFF
--- a/lib/JSON/RPC/Dispatcher.pm
+++ b/lib/JSON/RPC/Dispatcher.pm
@@ -318,12 +318,12 @@ sub handle_procedures {
                 }
                 elsif ($@) {
                     my $error = $@;
-                    if ($error->can('error') && $error->can('trace')) {
+                    if (blessed($error) && $error->can('error') && $error->can('trace')) {
                          $log->fatal($error->error);
                          $log->trace($error->trace->as_string);
                          $error = $error->error;
                     }
-                    elsif ($error->can('error')) {
+                    elsif (blessed($error) && $error->can('error')) {
                         $error = $error->error;
                         $log->fatal($error);
                     }

--- a/lib/JSON/RPC/Dispatcher.pm
+++ b/lib/JSON/RPC/Dispatcher.pm
@@ -46,6 +46,9 @@ This module follows the draft specficiation for JSON-RPC 2.0. More information c
 
 =head2 Registration Options
 
+The C<register> method cannot be used to register methods that start with m/^rpc\./.  Per the JSON-RPC 2.0 specification, these are reserved for 
+rpc-internal extensions.
+
 The C<register> method takes a third argument which is a hash reference of named options that effects how the code should be handled.
 
 =head3 with_plack_request
@@ -175,6 +178,13 @@ sub clear_error {
 #--------------------------------------------------------
 sub register {
     my ($self, $name, $sub, $options) = @_;
+
+	if(defined($name) && $name =~ m{^rpc\.}) { 
+		die "$name is an invalid name for a method. (Methods matching m/^rpc\\./ are reserved for rpc-internal procedures)";
+	} elsif(!defined($name) || $name eq '' || ref($name)) {
+		die "Registered method name must be a defined non-empty string and not start with 'rpc.'";	
+	}
+ 
     my $rpcs = $self->rpcs;
     $rpcs->{$name} = {
         function            => $sub,

--- a/lib/JSON/RPC/Dispatcher/Procedure.pm
+++ b/lib/JSON/RPC/Dispatcher/Procedure.pm
@@ -175,19 +175,13 @@ Returns the name of the procedure to be called.
 
 =head3 name
 
-An alphanumeric string. Sets the method name. Will set an error if the method name is not alpha-numeric.
+Per specification, any string is accepted as a potential JSON-RPC method name.
 
 =cut
 
 has method  => (
     is      => 'rw',
     default => undef,
-    trigger => sub {
-            my ($self, $new, $old) = @_;
-            if (defined $new && $new !~ m{^[A-Za-z0-9_]+$}xms) {
-                $self->invalid_request($new.' is not a valid method name.');
-            }
-        },
 );
 
 #--------------------------------------------------------

--- a/t/01.ValidMethodNames.t
+++ b/t/01.ValidMethodNames.t
@@ -1,0 +1,55 @@
+use Test::More;
+use JSON::RPC::Dispatcher;
+
+my @valid = (
+		# some of these are absurd, but the spec says any string is a valid method name.
+		'name1',
+		'name.foo',
+		'name/foo',
+		'[name]',
+		'a name with spaces',
+		'{name}foo',
+		'http://www.foo.com/foo',
+		'!@%!@#%!@#$!@#$!@#%',
+		'გთხოვთ ახლავე',
+		'0',
+		'false',
+		'0 but true',
+);
+
+my @invalid = (
+		'rpc.foo',
+		'rpc.გთხოვთ ახლავე',
+		'',
+		undef,
+		{},
+		[qw(ref)],
+);
+
+plan tests=>@valid + @invalid;
+
+my $dist = JSON::RPC::Dispatcher->new();
+foreach my $valid (@valid) { 
+	my $accepted = eval { 
+		$dist->register($valid=>sub { return 'ok' });
+		return 1;
+	};
+	if($accepted) { 
+		pass("Accepted a valid symbol name");
+	} else { 
+		fail("Rejected a valid symbol name: $valid with error $@");
+	}
+};
+
+foreach my $invalid (@invalid) { 
+	my $accepted = eval { 
+		$dist->register($invalid=>sub { return 'ok' });
+		return 1;
+	};
+	if($accepted) { 
+		fail("Accepted an invalid symbol name: $invalid");
+	} else { 
+		pass("Rejected an nvalid symbol name");
+	}
+}
+


### PR DESCRIPTION
The JSON-RPC 2.0 spec says that any string is a valid method name, and I couldn't find any mention on their discussion list of an alphanumeric requirement on method names.

This patch will expand your dispatcher to accept registration on any method names, except empty string, non-string scalars, or any strings starting with 'rpc.' and on activation, accept any method names (in case you ever internally introduce "rpc." methods).

I've also included relevent test cases.

Thanks for this module, and thanks for your consideration.  This is my first github/cpan pull request, I hope I'm not being improper :)
